### PR TITLE
Updating the requirements to point to forked django-rest-swagger package

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -4,8 +4,8 @@ PyYAML==3.11
 boto==2.34.0
 coverage==3.7.1
 django-hstore==1.2.3
--e git://github.com/18F/django-rest-swagger.git@fix-url-grouping#egg=django-rest-swagger
-djangorestframework==2.3.14
+-e git://github.com/PSHCDevOps/django-rest-swagger.git@ssl_termination_fix#egg=django-rest-swagger
+djangorestframework==2.4.8
 psycopg2==2.5.3
 pytz==2014.4
 requests==2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ boto==2.34.0
 coverage==3.7.1
 django-hstore==1.2.3
 -e git://github.com/PSHCDevOps/django-rest-swagger.git@ssl_termination_fix#egg=django-rest-swagger
-djangorestframework==2.4.8
+djangorestframework==2.3.14
 psycopg2==2.5.3
 pytz==2014.4
 requests==2.3.0


### PR DESCRIPTION
And upgrading django rest framework (to latest minor release).

Not fully tested on Cloud.gov yet...