### PR TITLE
Refactoring the JS event model

### DIFF
--- a/app/acceptance/test_home.py
+++ b/app/acceptance/test_home.py
@@ -23,6 +23,7 @@ class HomeTest(case.AcceptanceTestCase, metaclass = case.MetaAcceptanceSchema):
             'params': {
                 'vehicle': 'OASIS_SB'
             },
+            'wait': ('sec', 1),
             'pool-id': 'enabled'
         },
         'zone_filter': {
@@ -35,7 +36,7 @@ class HomeTest(case.AcceptanceTestCase, metaclass = case.MetaAcceptanceSchema):
             'params': {
                 'vehicle': 'OASIS_SB'
             },
-            'css:.se_filter': 'disabled'
+            'css:.se_filter': 'enabled'
         },
         'load_dates': {
             'wait': ('sec', 2),

--- a/app/discovery/static/discovery_site/js/input-handler.js
+++ b/app/discovery/static/discovery_site/js/input-handler.js
@@ -64,6 +64,13 @@ var InputHandler = {
             }
         }
 
+        if (obj['type']) {
+            this.listType = obj['type'];
+        }
+        else {
+            this.listType = 'naics';
+        }
+
         LayoutManager.toggleZones();
         EventManager.publish('fieldsUpdated');
     },
@@ -92,7 +99,7 @@ var InputHandler = {
             //reset other ths that are sortable
             $target.siblings('.sortable').removeClass('arrow-down').removeClass('arrow-up').addClass('arrow-sortable').attr("title", "Select to sort");
 
-            EventManager.publish('vendorsChanged', data);
+            EventManager.publish('vendorsSorted', data);
         }
     },
 
@@ -101,8 +108,7 @@ var InputHandler = {
         if ((e.type == "keypress" && e.charCode == 13) || e.type == "click") {
             var $target = $(e.target);
             var data = {
-                'naics': this.getNAICSCode(),
-                'listType': 'naics',
+                'naics': this.getNAICSCode()
             };
             var class_map = RequestsManager.sortClassMap();
             var classes = $target.attr('class').split(' ');
@@ -125,22 +131,19 @@ var InputHandler = {
 
             //prevent button flipping by selecting proper listType
             var $button = $("#vendor_contract_history_title_container").find('.contracts_button_active');
-            if ($button.text() == "All Contracts") { data['listType'] = 'all'; }
-            else { data['listType'] = 'naics'; }
+            if ($button.text() == "All Contracts") { this.listType = 'all'; }
+            else { this.listType = 'naics'; }
 
-            EventManager.publish('contractsChanged', data);
+            EventManager.publish('contractsSorted', data);
         }
     },
 
     sendContractsChange: function(e) {
         if ((e.type == "keypress" && e.charCode == 13) || e.type == "click") {
-            var listType = 'naics';
+            this.listType = 'naics';
 
             if(e.target.textContent == "All Contracts" || e.target.innerText == "All Contracts"){
-                this.naicsCode = 'all';
-                listType = 'all';
-            } else {
-                this.naicsCode = $("#vendor_contract_history_title_container").find("div").first().text().replace(/\D/g,'').trim();
+                this.listType = 'all';
             }
 
             //reset date header column classes
@@ -148,17 +151,16 @@ var InputHandler = {
             $date.removeClass('arrow-sortable').addClass('arrow-down').attr("title", "Sorted descending");
             $date.siblings('.sortable').removeClass('arrow-down').removeClass('arrow-up').addClass('arrow-sortable').attr("title", "Select to sort");
 
-            EventManager.publish('contractsChanged', {'page': 1, 'naics': this.naicsCode, 'listType': listType});
-            return false;
+            EventManager.publish('contractsChanged', {});
         }
     },
 
     sendPoolFilterContractsChange: function() {
-        var listType = 'naics';
+        this.listType = 'naics';
 
         var $button = $("#vendor_contract_history_title_container").find('.contracts_button_active');
         if ($button.text() == "All Contracts") {
-            listType = 'all';
+            this.listType = 'all';
         }
 
         //reset date header column classes
@@ -168,11 +170,7 @@ var InputHandler = {
 
         RequestsManager.pool = this.getContractPools();
 
-        EventManager.publish('contractsChanged', {
-            'page': 1,
-            'listType': listType
-        });
-        return false;
+        //EventManager.publish('contractsChanged', {});
     },
 
     sendVehicleChange: function() {
@@ -257,6 +255,10 @@ var InputHandler = {
         });
 
         return pools;
+    },
+
+    getListType: function() {
+        return this.listType;
     },
 
     loadPools: function() {

--- a/app/discovery/static/discovery_site/js/input-handler.js
+++ b/app/discovery/static/discovery_site/js/input-handler.js
@@ -170,7 +170,7 @@ var InputHandler = {
 
         RequestsManager.pool = this.getContractPools();
 
-        //EventManager.publish('contractsChanged', {});
+        EventManager.publish('contractsChanged', {});
     },
 
     sendVehicleChange: function() {

--- a/app/discovery/static/discovery_site/js/layout-manager-index.js
+++ b/app/discovery/static/discovery_site/js/layout-manager-index.js
@@ -1,16 +1,15 @@
 
 LayoutManager.initializers.index = function() {
-    EventManager.subscribe('naicsChanged', this.route.bind(LayoutManager));
+    EventManager.subscribe('dataChanged', this.route.bind(LayoutManager));
     EventManager.subscribe('loadPage', this.vehicleInfo.bind(LayoutManager));
 
     this.hideZones();
-    this.disableFilters();
 };
 
 LayoutManager.route = function(data) {
     var queryObject = RequestsManager.buildRequestQuery();
 
-    if ('naics' in queryObject) {
+    if ('naics' in queryObject || 'vehicle' in queryObject || 'pool' in queryObject) {
         this.loadPoolPage();
     }
 };

--- a/app/discovery/static/discovery_site/js/layout-manager-listings.js
+++ b/app/discovery/static/discovery_site/js/layout-manager-listings.js
@@ -1,6 +1,5 @@
 
 LayoutManager.initializers.listings = function() {
-    EventManager.subscribe('vendorDataLoaded', this.renderTable.bind(LayoutManager));
 };
 
 LayoutManager.render = function(results) {

--- a/app/discovery/static/discovery_site/js/layout-manager-vendor.js
+++ b/app/discovery/static/discovery_site/js/layout-manager-vendor.js
@@ -1,15 +1,15 @@
 
 LayoutManager.initializers.vendor = function() {
-    EventManager.subscribe('vendorPoolLoaded', this.renderVendor.bind(LayoutManager));
-    EventManager.subscribe('contractDataLoaded', this.renderTable.bind(LayoutManager));
-    EventManager.subscribe('pageUpdated', this.renderButtonAndCSV(LayoutManager));
+    EventManager.subscribe('vendorInitialized', this.renderVendor.bind(LayoutManager));
+    EventManager.subscribe('vendorInitialized', this.renderButtonAndCSV(LayoutManager));
 };
 
 LayoutManager.render = function(results) {
     this.renderVendor(results);
 };
 
-LayoutManager.renderVendor = function(vendor) {
+LayoutManager.renderVendor = function(data) {
+    var vendor = RequestsManager.vendor;
     var pools = {};
 
     if (! $.isEmptyObject(RequestsManager.vehiclePools)) {
@@ -166,7 +166,9 @@ LayoutManager.renderTable = function(results, listType, pageNumber, itemsPerPage
     LayoutManager.renderPager(listType, results, pageNumber, itemsPerPage);
 };
 
-LayoutManager.renderButtonAndCSV = function(listType){
+LayoutManager.renderButtonAndCSV = function(data) {
+    var listType = data['listType'];
+
     if (typeof listType != 'string' || ! ['all', 'naics'].includes(listType)) {
         listType = 'naics';
 

--- a/app/discovery/static/discovery_site/js/layout-manager-vendor.js
+++ b/app/discovery/static/discovery_site/js/layout-manager-vendor.js
@@ -96,6 +96,8 @@ LayoutManager.renderVendor = function(data) {
 
         this.renderButtonAndCSV('all');
     }
+
+    EventManager.publish('vendorRendered', {});
 };
 
 LayoutManager.renderContacts = function(vendor, pools) {

--- a/app/discovery/static/discovery_site/js/layout-manager-vendor.js
+++ b/app/discovery/static/discovery_site/js/layout-manager-vendor.js
@@ -1,11 +1,10 @@
 
 LayoutManager.initializers.vendor = function() {
-    EventManager.subscribe('vendorInitialized', this.renderVendor.bind(LayoutManager));
-    EventManager.subscribe('vendorInitialized', this.renderButtonAndCSV(LayoutManager));
+    EventManager.subscribe('contractsLoaded', this.renderTable.bind(LayoutManager));
 };
 
-LayoutManager.render = function(results) {
-    this.renderVendor(results);
+LayoutManager.render = function(data) {
+    this.renderVendor(data);
 };
 
 LayoutManager.renderVendor = function(data) {

--- a/app/discovery/static/discovery_site/js/layout-manager-vendor.js
+++ b/app/discovery/static/discovery_site/js/layout-manager-vendor.js
@@ -141,7 +141,8 @@ LayoutManager.renderColumn = function(v, prefix, setasideCode) {
     return $('<td class="' + prefix + '">' + this.vendorIndicator(v, prefix, setasideCode) + '</td>');
 };
 
-LayoutManager.renderTable = function(results, listType, pageNumber, itemsPerPage) {
+LayoutManager.renderTable = function(results, pageNumber, itemsPerPage) {
+    var listType = InputHandler.getListType();
     var $table = $('#vendor_contracts');
     var len = results['results'].length;
 
@@ -166,15 +167,7 @@ LayoutManager.renderTable = function(results, listType, pageNumber, itemsPerPage
 };
 
 LayoutManager.renderButtonAndCSV = function(data) {
-    var listType = data['listType'];
-
-    if (typeof listType != 'string' || ! ['all', 'naics'].includes(listType)) {
-        listType = 'naics';
-
-        if (URLManager.getParameterByName('showall')) {
-            listType = 'all';
-        }
-    }
+    var listType = InputHandler.getListType();
 
     $("#vendor_contract_history_title_container .contracts_button_active").attr('class', 'contracts_button');
     $("#" + listType + "_contracts_button").attr('class', 'contracts_button_active');

--- a/app/discovery/static/discovery_site/js/layout-manager.js
+++ b/app/discovery/static/discovery_site/js/layout-manager.js
@@ -4,9 +4,8 @@ var LayoutManager = {
 
     init: function() {
         if (URLManager.isHomePage() || URLManager.isPoolPage()) {
-            EventManager.subscribe('vehicleChanged', this.toggleZones.bind(LayoutManager));
-            EventManager.subscribe('poolUpdated', this.updatePoolInfo.bind(LayoutManager));
-            EventManager.subscribe('poolSelected', this.updatePoolInfo.bind(LayoutManager));
+            EventManager.subscribe('dataChanged', this.toggleZones.bind(LayoutManager));
+            EventManager.subscribe('dataChanged', this.updatePoolInfo.bind(LayoutManager));
             EventManager.subscribe('contentChanged', this.updateResultsInfo.bind(LayoutManager));
         }
         EventManager.subscribe('dataLoaded', this.render.bind(LayoutManager));

--- a/app/discovery/static/discovery_site/js/requests-manager-index.js
+++ b/app/discovery/static/discovery_site/js/requests-manager-index.js
@@ -1,6 +1,6 @@
 
 RequestsManager.initializers.index = function() {
-    EventManager.subscribe('poolUpdated', this.loadMetadata.bind(RequestsManager));
+    EventManager.subscribe('loadPage', this.loadMetadata.bind(RequestsManager));
 };
 
 RequestsManager.loadMetadata = function() {

--- a/app/discovery/static/discovery_site/js/requests-manager-listings.js
+++ b/app/discovery/static/discovery_site/js/requests-manager-listings.js
@@ -8,8 +8,6 @@ RequestsManager.sortClassMap = function() {
 };
 
 RequestsManager.initializers.listings = function() {
-    EventManager.subscribe('poolUpdated', this.load.bind(RequestsManager));
-    EventManager.subscribe('poolSelected', this.load.bind(RequestsManager));
     EventManager.subscribe('vendorsChanged', this.refreshVendors.bind(RequestsManager));
 };
 
@@ -79,13 +77,13 @@ RequestsManager.loadVendorData = function(data, callback) {
 RequestsManager.load = function() {
     if (URLManager.isPoolPage()) {
         RequestsManager.loadVendorData(RequestsManager.currentSortParams(), function(queryData, response) {
-            EventManager.publish('dataLoaded', response);
+            EventManager.publish('dataLoaded', response, 1, RequestsManager.getPageCount());
         });
     }
 };
 
 RequestsManager.refreshVendors = function(data) {
     RequestsManager.loadVendorData(data, function(queryData, response) {
-        EventManager.publish('vendorDataLoaded', response, data['page'], queryData['count']);
+        EventManager.publish('dataLoaded', response, data['page'], queryData['count']);
     });
 };

--- a/app/discovery/static/discovery_site/js/requests-manager-listings.js
+++ b/app/discovery/static/discovery_site/js/requests-manager-listings.js
@@ -9,6 +9,7 @@ RequestsManager.sortClassMap = function() {
 
 RequestsManager.initializers.listings = function() {
     EventManager.subscribe('vendorsChanged', this.refreshVendors.bind(RequestsManager));
+    EventManager.subscribe('vendorsSorted', this.refreshVendors.bind(RequestsManager));
 };
 
 RequestsManager.loadVendorData = function(data, callback) {

--- a/app/discovery/static/discovery_site/js/requests-manager-vendor.js
+++ b/app/discovery/static/discovery_site/js/requests-manager-vendor.js
@@ -12,9 +12,7 @@ RequestsManager.sortClassMap = function() {
 };
 
 RequestsManager.initializers.vendor = function() {
-    EventManager.subscribe('poolUpdated', this.refreshVendor.bind(RequestsManager));
-
-    EventManager.subscribe('vendorInfoLoaded', this.refreshContracts.bind(RequestsManager));
+    EventManager.subscribe('vendorInitialized', this.refreshContracts.bind(RequestsManager));
     EventManager.subscribe('contractsChanged', this.refreshContracts.bind(RequestsManager));
 };
 
@@ -58,7 +56,7 @@ RequestsManager.loadContracts = function(data, callback) {
     );
 };
 
-RequestsManager.refreshVendor = function() {
+RequestsManager.load = function() {
     var listType = 'naics';
 
     if (URLManager.getParameterByName('showall')) {
@@ -66,21 +64,19 @@ RequestsManager.refreshVendor = function() {
     }
 
     RequestsManager.loadVendor(function(duns, vendor) {
-        EventManager.publish('vendorPoolLoaded', vendor);
-        EventManager.publish('vendorInfoLoaded', {'listType': listType});
+        EventManager.publish('vendorInitialized', {'listType': listType});
     });
 };
 
 RequestsManager.refreshContracts = function(data) {
-    data['listType'] = typeof data['listType'] !== 'undefined' ? data['listType'] : 'naics';
-    data['naics'] = URLManager.getParameterByName('naics-code');
+    data['naics'] = InputHandler.getNAICSCode();
 
     if (!data['page']) {
         data['page'] = 1;
     }
 
     RequestsManager.loadContracts(data, function(queryData, response) {
-        EventManager.publish('contractDataLoaded', response, data['listType'], data['page'], queryData['count']);
+        EventManager.publish('dataLoaded', response, data['listType'], data['page'], queryData['count']);
     });
 };
 

--- a/app/discovery/static/discovery_site/js/requests-manager-vendor.js
+++ b/app/discovery/static/discovery_site/js/requests-manager-vendor.js
@@ -13,7 +13,7 @@ RequestsManager.sortClassMap = function() {
 
 RequestsManager.initializers.vendor = function() {
     EventManager.subscribe('dataLoaded', this.refreshContracts.bind(RequestsManager));
-    EventManager.subscribe('contractsChanged', this.refreshContracts.bind(RequestsManager));
+    EventManager.subscribe('contractsSorted', this.refreshContracts.bind(RequestsManager));
 };
 
 RequestsManager.loadVendor = function(callback) {
@@ -32,12 +32,14 @@ RequestsManager.loadContracts = function(data, callback) {
     var queryData = $.extend(data, {'vendor__duns': duns, 'count': this.getPageCount()});
     var piids = RequestsManager.getPIIDs();
 
-    queryData['psc_naics'] = queryData['naics'];
-    delete queryData['naics'];
+    if (InputHandler.getListType() == 'naics' && 'naics' in queryData) {
+        queryData['psc_naics'] = queryData['naics'];
 
-    if (queryData['psc_naics'] == 'all') {
-        delete queryData['psc_naics'];
+        if (queryData['psc_naics'] == 'all') {
+            delete queryData['psc_naics'];
+        }
     }
+    delete queryData['naics'];
 
     if (piids.length > 0) {
         queryData['base_piid__in'] = piids.join(',');
@@ -57,14 +59,8 @@ RequestsManager.loadContracts = function(data, callback) {
 };
 
 RequestsManager.load = function() {
-    var listType = 'naics';
-
-    if (URLManager.getParameterByName('showall')) {
-        listType = 'all';
-    }
-
     RequestsManager.loadVendor(function(duns, vendor) {
-        EventManager.publish('dataLoaded', {'listType': listType});
+        EventManager.publish('dataLoaded', {});
     });
 };
 
@@ -76,7 +72,7 @@ RequestsManager.refreshContracts = function(data) {
     }
 
     RequestsManager.loadContracts(data, function(queryData, response) {
-        EventManager.publish('contractsLoaded', response, data['listType'], data['page'], queryData['count']);
+        EventManager.publish('contractsLoaded', response, data['page'], queryData['count']);
     });
 };
 

--- a/app/discovery/static/discovery_site/js/requests-manager-vendor.js
+++ b/app/discovery/static/discovery_site/js/requests-manager-vendor.js
@@ -12,7 +12,7 @@ RequestsManager.sortClassMap = function() {
 };
 
 RequestsManager.initializers.vendor = function() {
-    EventManager.subscribe('dataLoaded', this.refreshContracts.bind(RequestsManager));
+    EventManager.subscribe('vendorRendered', this.refreshContracts.bind(RequestsManager));
     EventManager.subscribe('contractsSorted', this.refreshContracts.bind(RequestsManager));
 };
 

--- a/app/discovery/static/discovery_site/js/requests-manager-vendor.js
+++ b/app/discovery/static/discovery_site/js/requests-manager-vendor.js
@@ -12,7 +12,7 @@ RequestsManager.sortClassMap = function() {
 };
 
 RequestsManager.initializers.vendor = function() {
-    EventManager.subscribe('vendorInitialized', this.refreshContracts.bind(RequestsManager));
+    EventManager.subscribe('dataLoaded', this.refreshContracts.bind(RequestsManager));
     EventManager.subscribe('contractsChanged', this.refreshContracts.bind(RequestsManager));
 };
 
@@ -64,7 +64,7 @@ RequestsManager.load = function() {
     }
 
     RequestsManager.loadVendor(function(duns, vendor) {
-        EventManager.publish('vendorInitialized', {'listType': listType});
+        EventManager.publish('dataLoaded', {'listType': listType});
     });
 };
 
@@ -76,7 +76,7 @@ RequestsManager.refreshContracts = function(data) {
     }
 
     RequestsManager.loadContracts(data, function(queryData, response) {
-        EventManager.publish('dataLoaded', response, data['listType'], data['page'], queryData['count']);
+        EventManager.publish('contractsLoaded', response, data['listType'], data['page'], queryData['count']);
     });
 };
 

--- a/app/discovery/static/discovery_site/js/requests-manager.js
+++ b/app/discovery/static/discovery_site/js/requests-manager.js
@@ -7,13 +7,7 @@ var RequestsManager = {
     pool: null,
 
     init: function() {
-        if (URLManager.isHomePage() || URLManager.isPoolPage()) {
-            EventManager.subscribe('vehicleChanged', this.load.bind(RequestsManager));
-            EventManager.subscribe('poolChanged', this.load.bind(RequestsManager));
-            EventManager.subscribe('naicsChanged', this.load.bind(RequestsManager));
-            EventManager.subscribe('zoneChanged', this.load.bind(RequestsManager));
-            EventManager.subscribe('filtersChanged', this.load.bind(RequestsManager));
-        }
+        EventManager.subscribe('dataChanged', this.load.bind(RequestsManager));
 
         for(var handler in this.initializers){
             this.initializers[handler].call(this);
@@ -49,8 +43,8 @@ var RequestsManager = {
         var vehicle = InputHandler.getVehicle();
         var pools = RequestsManager.vehiclePools;
         var pool = InputHandler.getPool();
-        var naics = InputHandler.getNAICSCode() || URLManager.getParameterByName('naics-code');
-        var zone = InputHandler.getZone() || URLManager.getParameterByName('zone');
+        var naics = InputHandler.getNAICSCode();
+        var zone = InputHandler.getZone();
         var setasides = InputHandler.getSetasides();
         var contractPools = InputHandler.getContractPools();
         var queryData = {};

--- a/app/discovery/static/discovery_site/js/requests-manager.js
+++ b/app/discovery/static/discovery_site/js/requests-manager.js
@@ -53,8 +53,11 @@ var RequestsManager = {
         if (vehicle && vehicle != 'all') {
             queryData['vehicle'] = vehicle;
         }
-        if (contractPools.length > 0) {
-            queryData['pool'] = contractPools.join(',');
+
+        if (URLManager.isVendorPage()) {
+            if (contractPools.length > 0) {
+                queryData['pool'] = contractPools.join(',');
+            }
         }
         else if (pool && pool in pools) {
             queryData['pool'] = pool;

--- a/app/discovery/static/discovery_site/js/requests-manager.js
+++ b/app/discovery/static/discovery_site/js/requests-manager.js
@@ -47,6 +47,7 @@ var RequestsManager = {
         var zone = InputHandler.getZone();
         var setasides = InputHandler.getSetasides();
         var contractPools = InputHandler.getContractPools();
+        var listType = InputHandler.getListType();
         var queryData = {};
 
         if (vehicle && vehicle != 'all') {
@@ -68,6 +69,10 @@ var RequestsManager = {
 
         if (setasides.length > 0) {
             queryData["setasides"] = setasides.join(',');
+        }
+
+        if (listType) {
+            queryData['type'] = listType;
         }
 
         if (URLManager.getParameterByName('test')) {

--- a/app/discovery/static/discovery_site/js/url-manager.js
+++ b/app/discovery/static/discovery_site/js/url-manager.js
@@ -3,12 +3,15 @@ var URLManager = {
     title: 'Discovery',
 
     init: function() {
-        EventManager.subscribe('vehicleChanged', this.update.bind(URLManager));
-        EventManager.subscribe('poolSelected', this.update.bind(URLManager));
         EventManager.subscribe('naicsChanged', this.update.bind(URLManager));
+        EventManager.subscribe('vehicleChanged', this.update.bind(URLManager));
+        EventManager.subscribe('poolChanged', this.update.bind(URLManager));
         EventManager.subscribe('zoneChanged', this.update.bind(URLManager));
-        EventManager.subscribe('contentChanged', this.update.bind(URLManager));
-        EventManager.subscribe('contractsChanged', this.update.bind(URLManager));
+        EventManager.subscribe('filtersChanged', this.update.bind(URLManager));
+
+        //EventManager.subscribe('contractsChanged', this.update.bind(URLManager));
+
+        EventManager.subscribe('pageUpdated', this.initFromQS.bind(URLManager));
 
         this.initFromQS();
     },

--- a/app/discovery/static/discovery_site/js/url-manager.js
+++ b/app/discovery/static/discovery_site/js/url-manager.js
@@ -9,7 +9,7 @@ var URLManager = {
         EventManager.subscribe('zoneChanged', this.update.bind(URLManager));
         EventManager.subscribe('filtersChanged', this.update.bind(URLManager));
 
-        //EventManager.subscribe('contractsChanged', this.update.bind(URLManager));
+        EventManager.subscribe('contractsChanged', this.update.bind(URLManager));
 
         EventManager.subscribe('pageUpdated', this.initFromQS.bind(URLManager));
 
@@ -22,6 +22,7 @@ var URLManager = {
         var naics = this.getParameterByName('naics-code');
         var zone = this.getParameterByName('zone');
         var setasides = this.getParameterByName('setasides');
+        var type = this.getParameterByName('type');
         var data = {};
 
         if (vehicle) {
@@ -38,6 +39,9 @@ var URLManager = {
         }
         if (setasides) {
             data['setasides'] = setasides;
+        }
+         if (type) {
+            data['type'] = type;
         }
 
         LayoutManager.route(data);

--- a/app/discovery/static/discovery_site/js/url-manager.js
+++ b/app/discovery/static/discovery_site/js/url-manager.js
@@ -150,7 +150,7 @@ var URLManager = {
     },
 
     isVendorPage: function() {
-        var pathArray =  window.location.pathname.split('/').join('').split('');
+        var pathArray =  window.location.pathname.split('/');
 
         if ($.inArray('vendor', pathArray) !== -1) {
             return true;

--- a/app/discovery/templates/search_base.html
+++ b/app/discovery/templates/search_base.html
@@ -7,7 +7,7 @@
         <div id="search-main">
             <div id="search-focus">
                 <div id="naics_select">
-                    <span class="select_text">Choose NAICS category</span>
+                    <span class="select_text">Select an NAICS Code / Description</span>
                     <form id="naics-search" class="pure-form">
                         <select id="naics-code" class="search_text_style" title="Select a NAICS code or description"></select>
                     </form>


### PR DESCRIPTION
Create an event layer that updates query parameters and reloads JS elements instead of having events take care of this themselves.  This should fix problems with the query parameters getting desynced from the filter selections and allow for more reliable dependent input updates.

Not ready to merge yet