### PR TITLE
Cloud.gov deployment fix

### DIFF
--- a/.cfignore
+++ b/.cfignore
@@ -13,7 +13,6 @@ __pycache__
 /tmp/
 
 /app/discovery/local_settings.py
-/app/static/
 /cf/
 /db/
 /docker/

--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -233,6 +233,12 @@ jobs:
       - checkout
 
       - run:
+          name: Build static files
+          command: |
+            ./scripts/setup-angular.sh /dev/stderr
+            ./scripts/init-webserver.sh /dev/stderr
+
+      - run:
           name: Setup CloudFoundry client CLI
           command: |
             ./scripts/setup-cf.sh /dev/stderr
@@ -258,6 +264,12 @@ jobs:
             apt-get install -y git
 
       - checkout
+
+      - run:
+          name: Build static files
+          command: |
+            ./scripts/setup-angular.sh /dev/stderr
+            ./scripts/init-webserver.sh /dev/stderr
 
       - run:
           name: Setup CloudFoundry client CLI

--- a/cf/base-web-manifest.yml
+++ b/cf/base-web-manifest.yml
@@ -1,7 +1,7 @@
 ---
 inherit: base-manifest.yml
 
-command: scripts/init-webserver.sh /dev/stderr && cd app && waitress-serve --expose-tracebacks --url-scheme=https --port=$PORT discovery.wsgi:application
+command: cd app && waitress-serve --expose-tracebacks --url-scheme=https --port=$PORT discovery.wsgi:application
 memory: 256M
 services:
   - discovery-config

--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.5
+python-3.6.6


### PR DESCRIPTION
Removing building of static files on the Cloud.gov instances in favor of building in the CircleCI environment and deploying from there.  This is necessary because the Python buildpack does not contain the necessary node and angular dependencies to build the angular application.