### PR TITLE
Restricting API paging counts to specific values

### DIFF
--- a/app/api/mixins.py
+++ b/app/api/mixins.py
@@ -1,4 +1,7 @@
 from discovery.utils import check_api_test
+
+from rest_framework.exceptions import ParseError
+
 from api.pagination import TestResultSetPagination, ResultNoPagination
 
 
@@ -28,23 +31,43 @@ class PaginationViewSetMixin(object):
     
     @property
     def paginator(self):
+        page = self._get_query_param('page')
+        count = self._get_query_param('count')
+        
         if not hasattr(self, '_paginator'):
             if self.pagination_class is None:
                 self._paginator = None
             elif check_api_test(self.request):
                 self._paginator = TestResultSetPagination()
-            elif self.bypass_pagination and not self._allow_pagination(self.request):
+            elif self.bypass_pagination and not self._use_pagination(page):
                 self._paginator = ResultNoPagination()
             else:
+                self._validate_page_count(count)
                 self._paginator = self.pagination_class()
         
         return self._paginator
     
     
-    def _allow_pagination(self, request = None):
-        if request and 'page' in request.query_params and int(request.query_params['page']) == 0:
+    def _validate_page_count(self, count):
+        if self.bypass_pagination:
+            count_options = [0, 5, 10, 20, 50, 100]
+        else:
+            count_options = [5, 10, 20, 50, 100]
+        
+        if count and int(count) not in count_options:
+            raise ParseError("Paging count {} is not valid.  Choose from: {}".format(count, ", ".join(str(x) for x in count_options)))
+    
+    def _use_pagination(self, page):
+        if page and int(page) == 0:
             return False
         return True
+    
+    
+    def _get_query_param(self, name):
+        if self.request and name in self.request.query_params:
+            return self.request.query_params[name]
+        return None
+        
 
 
 class SerializerViewSetMixin(object):

--- a/app/api/pagination.py
+++ b/app/api/pagination.py
@@ -21,7 +21,7 @@ class BasePagination(PageNumberPagination):
 
 class ResultSetPagination(BasePagination): 
     page_size = settings.REST_PAGE_COUNT
-    max_page_size = 1000
+    max_page_size = 100
 
 
 class ResultNoPagination(BasePagination):


### PR DESCRIPTION
This is to help ensure better performance through easier caching.

The accepted paging counts will now be:
0 - If model supports it
5, 10, 20, 50, 100