### PR TITLE
Hotfix: Adding iterator to the vendor CSV views listings.

### DIFF
--- a/app/acceptance/test_vendor.py
+++ b/app/acceptance/test_vendor.py
@@ -72,7 +72,7 @@ class VendorTest(case.AcceptanceTestCase, metaclass = case.MetaAcceptanceSchema)
                 'membership_filters': (None, 1, 0, 0, {
                     1: ('Ian Hada', '202-625-4239', 'Ianh@donohoe.com')
                 }),
-                'vendor_sam': ('9/18/18',),
+                'vendor_sam': ('9/18/18', True),
                 'vendor_info': ('COMPLETE BUILDING SERVICES', '808649888', '4YAL6', '550', '$26'),
                 'vendor_address': ('5151 Wisconsin Ave Nw Ste 400', 'Washington, DC 20016', True),
                 'vendor_badges': (),
@@ -561,7 +561,7 @@ class VendorTest(case.AcceptanceTestCase, metaclass = case.MetaAcceptanceSchema)
                 }, {
                     1: ('SB', 'SDB', 'VO', 'SDVO')
                 }),
-                'vendor_sam': ('9/21/18',),
+                'vendor_sam': ('9/21/18', True),
                 'vendor_info': ('SDAC FACILITY SERVICE LLC', '079515381', '77M00', '1', '$1'),
                 'vendor_address': ('14510 Sw 284Th St', 'Homestead, FL 33033', False),
                 'vendor_badges': (True,),

--- a/app/vendors/views.py
+++ b/app/vendors/views.py
@@ -183,7 +183,7 @@ def PoolCSV(request):
 
     lines = []
 
-    for v in vendors:
+    for v in vendors.iterator():
         setaside_list = []
         for sa in setasides_all:
             if sa.id in v.pools.all().values_list('setasides', flat=True):
@@ -332,7 +332,7 @@ def VendorCSV(request, vendor_duns):
     
     writer.writerow(('Date Signed', 'PIID', 'Agency', 'Type', 'Value ($)', 'Email POC', 'Status'))
 
-    for contract in contracts:
+    for contract in contracts.iterator():
         pricing_type = ''
         status = ''
         


### PR DESCRIPTION
If my assumption is correct about the cause of the intermittent failure of the vendor CSV view, adding a query iterator in Django's ORM handling should help prevent it from using up too many resources in cases where there are a lot of vendors in the CSV file.