### PR TITLE
Hotfix: CloudFoundry buildpack python version bump

### DIFF
--- a/runtime.txt
+++ b/runtime.txt
@@ -1,1 +1,1 @@
-python-3.6.5
+python-3.6.6


### PR DESCRIPTION
Current 3.6.5 on master branch will no longer deploy.