### PR TITLE
Vendors API membership filter query fix

### DIFF
--- a/app/api/filters.py
+++ b/app/api/filters.py
@@ -331,7 +331,7 @@ class VendorFilter(VendorBaseFilter):
         ms_ids = list(ms_queryset.values_list('id', flat=True))
         
         # Filter vendors by membership
-        if len(ms_ids) > 0:
+        if len(querystrings) > 0:
             qs = qs.filter(pools__id__in=ms_ids)
         
         return qs

--- a/app/api/tests/test_vendor.py
+++ b/app/api/tests/test_vendor.py
@@ -518,6 +518,14 @@ class VendorTest(case.APITestCase, metaclass = case.MetaAPISchema):
                         ('pools__pool__vehicle__id', 'exact', 'PSS'),
                         ('pools__setasides__code', 'in', ('A6', 'XX')),
                     )
+                },
+                '-membership2': {
+                    'tags': ('vendor_request',),
+                    'params': {'membership': '(pool__vehicle__id=BMO)&(setasides__code=A6)&(setasides__code=XX)'},
+                    'tests': (
+                        ('pools__pool__vehicle__id', 'exact', 'BMO'),
+                        ('pools__setasides__code', 'in', ('A6', 'XX')),
+                    )
                 }
             }
         }


### PR DESCRIPTION
Fixing an issue where results with no membership ids return all vendors.