### PR TITLE
Frontend fixes

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -71,6 +71,7 @@ Vagrant.configure("2") do |config|
 
   config.vm.network :forwarded_port, guest: 1936, host: vm_config["haproxy_port"]
   config.vm.network :forwarded_port, guest: 8080, host: vm_config["web_port"]
+  config.vm.network :forwarded_port, guest: 4200, host: vm_config["angular_port"]
   config.vm.network :forwarded_port, guest: 5432, host: vm_config["db_port"]
   config.vm.network :forwarded_port, guest: 6379, host: vm_config["queue_port"]
   config.vm.network :forwarded_port, guest: 8089, host: vm_config['locust_port']

--- a/app/frontend/angular.json
+++ b/app/frontend/angular.json
@@ -48,7 +48,8 @@
         "serve": {
           "builder": "@angular-devkit/build-angular:dev-server",
           "options": {
-            "browserTarget": "discovery:build"
+            "browserTarget": "discovery:build",
+            "host": "0.0.0.0"
           },
           "configurations": {
             "production": {

--- a/app/frontend/src/app/pages/contract-vehicles/pss.component.html
+++ b/app/frontend/src/app/pages/contract-vehicles/pss.component.html
@@ -7,7 +7,7 @@
 
 <section class="usa-section">
   <div class="usa-grid">
-    <div class="usa-width-one-sixth"></div>
+    <div class="usa-width-one-sixth">&nbsp;</div>
     <div class="usa-width-one-half">
       <p class="usa-font-lead">The Professional Services Schedule (PSS) is an indefinite delivery/indefinite quantity
         (IDIQ) multiple award schedule, providing direct access to simple or complex fixed-price or labor-hour

--- a/app/frontend/src/app/pages/search/filters/filter-psc.component.ts
+++ b/app/frontend/src/app/pages/search/filters/filter-psc.component.ts
@@ -104,9 +104,7 @@ export class FilterPscComponent implements OnInit, OnChanges {
         item['description'] = psc.description;
         item['vehicle_id'] = pool.vehicle.id;
         item['pool_id'] = pool.id;
-        if (!this.searchService.existsIn(pscs, psc.code, 'id')) {
-          pscs.push(item);
-        }
+        pscs.push(item);
       }
     }
     pscs.sort(this.searchService.sortByIdAsc);

--- a/vagrant/config.default.yml
+++ b/vagrant/config.default.yml
@@ -12,6 +12,7 @@ cpus: 2
 memory_size: 2048
 haproxy_port: 1936
 web_port: 8080
+angular_port: 4200
 db_port: 5432
 queue_port: 6379
 locust_port: 8089


### PR DESCRIPTION
* Fixing the ng serve availability through the Vagrant virtual machine (shared port 4200 / listening on 0.0.0.0 interface)
* Fixing the display of the contract service categories when PSC values selected
* Fixing width / positioning of PSS contract information