### PR TITLE
Develop docs

### DIFF
--- a/app/docs/templates/doc-index.html
+++ b/app/docs/templates/doc-index.html
@@ -89,10 +89,10 @@
 </ul>
 <p class="caption"><span class="caption-text">Links</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://discovery.gsa.gov/">Discovery live</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://discovery-dev.app.cloud.gov/">Discovery development</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/PSHCDevOps/discovery/">GitHub project</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://trello.com/b/AEoWtET7/discovery-20/">Trello board</a></li>
+<li class="toctree-l1"><a class="reference external" target="_blank" rel="noopener noreferrer" href="https://discovery.gsa.gov/">Discovery live</a></li>
+<li class="toctree-l1"><a class="reference external" target="_blank" rel="noopener noreferrer" href="https://discovery-dev.app.cloud.gov/">Discovery development</a></li>
+<li class="toctree-l1"><a class="reference external" target="_blank" rel="noopener noreferrer" href="https://github.com/PSHCDevOps/discovery/">GitHub project</a></li>
+<li class="toctree-l1"><a class="reference external" target="_blank" rel="noopener noreferrer" href="https://trello.com/b/AEoWtET7/discovery-20/">Trello board</a></li>
 </ul>
 <p class="caption"><span class="caption-text">Getting Started</span></p>
 <ul>
@@ -188,10 +188,10 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Links</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference external" href="https://discovery.gsa.gov/">Discovery live</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://discovery-dev.app.cloud.gov/">Discovery development</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://github.com/PSHCDevOps/discovery/">GitHub project</a></li>
-<li class="toctree-l1"><a class="reference external" href="https://trello.com/b/AEoWtET7/discovery-20/">Trello board</a></li>
+<li class="toctree-l1"><a class="reference external" target="_blank" rel="noopener noreferrer" href="https://discovery.gsa.gov/">Discovery live</a></li>
+<li class="toctree-l1"><a class="reference external" target="_blank" rel="noopener noreferrer" href="https://discovery-dev.app.cloud.gov/">Discovery development</a></li>
+<li class="toctree-l1"><a class="reference external" target="_blank" rel="noopener noreferrer" href="https://github.com/PSHCDevOps/discovery/">GitHub project</a></li>
+<li class="toctree-l1"><a class="reference external" target="_blank" rel="noopener noreferrer" href="https://trello.com/b/AEoWtET7/discovery-20/">Trello board</a></li>
 </ul>
 </div>
 <div class="toctree-wrapper compound">
@@ -221,20 +221,20 @@
 <li class="toctree-l2"><a class="reference internal" href="docs/start/vagrant.html#getting-help">Getting help</a></li>
 </ul>
 </li>
-<li class="toctree-l1"><a class="reference internal" href="start/docker.html">Discovery on Docker</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="start/docker.html#installation">Installation</a></li>
-<li class="toctree-l2"><a class="reference internal" href="start/docker.html#configuration">Configuration</a></li>
-<li class="toctree-l2"><a class="reference internal" href="start/docker.html#running-the-docker-services">Running the Docker services</a></li>
-<li class="toctree-l2"><a class="reference internal" href="start/docker.html#common-docker-commands">Common Docker commands</a></li>
-<li class="toctree-l2"><a class="reference internal" href="start/docker.html#getting-help">Getting help</a></li>
+<li class="toctree-l1"><a class="reference internal" href="docs/start/docker.html">Discovery on Docker</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="docs/start/docker.html#installation">Installation</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/start/docker.html#configuration">Configuration</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/start/docker.html#running-the-docker-services">Running the Docker services</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/start/docker.html#common-docker-commands">Common Docker commands</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/start/docker.html#getting-help">Getting help</a></li>
 </ul>
 </li>
-<li class="toctree-l1"><a class="reference internal" href="start/setup.html">Discovery setup</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="start/setup.html#server-initialization-scripts">Server initialization scripts</a></li>
-<li class="toctree-l2"><a class="reference internal" href="start/setup.html#data-loading">Data loading</a></li>
-<li class="toctree-l2"><a class="reference internal" href="start/setup.html#testing-changes">Testing changes</a></li>
-<li class="toctree-l2"><a class="reference internal" href="start/setup.html#deployment-information">Deployment information</a></li>
-<li class="toctree-l2"><a class="reference internal" href="start/setup.html#documentation-generation">Documentation generation</a></li>
+<li class="toctree-l1"><a class="reference internal" href="docs/start/setup.html">Discovery setup</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="docs/start/setup.html#server-initialization-scripts">Server initialization scripts</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/start/setup.html#data-loading">Data loading</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/start/setup.html#testing-changes">Testing changes</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/start/setup.html#deployment-information">Deployment information</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/start/setup.html#documentation-generation">Documentation generation</a></li>
 </ul>
 </li>
 </ul>
@@ -242,42 +242,42 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Architecture</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="architecture/readme.html">Architecture and design</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="architecture/readme.html#overview">Overview</a></li>
-<li class="toctree-l2"><a class="reference internal" href="architecture/readme.html#topics">Topics</a></li>
+<li class="toctree-l1"><a class="reference internal" href="docs/architecture/readme.html">Architecture and design</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="docs/architecture/readme.html#overview">Overview</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/architecture/readme.html#topics">Topics</a></li>
 </ul>
 </li>
-<li class="toctree-l1"><a class="reference internal" href="architecture/technologies.html">Discovery technologies</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="architecture/technologies.html#dockerized-development">Dockerized development</a></li>
-<li class="toctree-l2"><a class="reference internal" href="architecture/technologies.html#cloud-foundry-hosting">Cloud Foundry hosting</a></li>
-<li class="toctree-l2"><a class="reference internal" href="architecture/technologies.html#circleci-integration-and-deployment">CircleCI integration and deployment</a></li>
-<li class="toctree-l2"><a class="reference internal" href="architecture/technologies.html#django-web-framework">Django web framework</a></li>
-<li class="toctree-l2"><a class="reference internal" href="architecture/technologies.html#celery-task-scheduling-and-management">Celery task scheduling and management</a></li>
-<li class="toctree-l2"><a class="reference internal" href="architecture/technologies.html#postgresql-database">PostgreSQL database</a></li>
-<li class="toctree-l2"><a class="reference internal" href="architecture/technologies.html#redis-datastore">Redis datastore</a></li>
+<li class="toctree-l1"><a class="reference internal" href="docs/architecture/technologies.html">Discovery technologies</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="docs/architecture/technologies.html#dockerized-development">Dockerized development</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/architecture/technologies.html#cloud-foundry-hosting">Cloud Foundry hosting</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/architecture/technologies.html#circleci-integration-and-deployment">CircleCI integration and deployment</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/architecture/technologies.html#django-web-framework">Django web framework</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/architecture/technologies.html#celery-task-scheduling-and-management">Celery task scheduling and management</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/architecture/technologies.html#postgresql-database">PostgreSQL database</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/architecture/technologies.html#redis-datastore">Redis datastore</a></li>
 </ul>
 </li>
-<li class="toctree-l1"><a class="reference internal" href="architecture/design.html">Discovery system and frontend design</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="architecture/design.html#overview">Overview</a></li>
-<li class="toctree-l2"><a class="reference internal" href="architecture/design.html#configuration">Configuration</a></li>
-<li class="toctree-l2"><a class="reference internal" href="architecture/design.html#api">API</a></li>
-<li class="toctree-l2"><a class="reference internal" href="architecture/design.html#website">Website</a></li>
-<li class="toctree-l2"><a class="reference internal" href="architecture/design.html#scheduler-and-worker-processes">Scheduler and worker processes</a></li>
+<li class="toctree-l1"><a class="reference internal" href="docs/architecture/design.html">Discovery system and frontend design</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="docs/architecture/design.html#overview">Overview</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/architecture/design.html#configuration">Configuration</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/architecture/design.html#api">API</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/architecture/design.html#website">Website</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/architecture/design.html#scheduler-and-worker-processes">Scheduler and worker processes</a></li>
 </ul>
 </li>
-<li class="toctree-l1"><a class="reference internal" href="architecture/data.html">Discovery data</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="architecture/data.html#overview">Overview</a></li>
-<li class="toctree-l2"><a class="reference internal" href="architecture/data.html#classification-information">Classification information</a></li>
-<li class="toctree-l2"><a class="reference internal" href="architecture/data.html#vendor-information">Vendor information</a></li>
-<li class="toctree-l2"><a class="reference internal" href="architecture/data.html#contract-information">Contract information</a></li>
-<li class="toctree-l2"><a class="reference internal" href="architecture/data.html#scheduling-updates-and-monitoring-progress">Scheduling updates and monitoring progress</a></li>
-<li class="toctree-l2"><a class="reference internal" href="architecture/data.html#a-look-at-how-discovery-data-fits-together">A look at how Discovery data fits together</a></li>
+<li class="toctree-l1"><a class="reference internal" href="docs/architecture/data.html">Discovery data</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="docs/architecture/data.html#overview">Overview</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/architecture/data.html#classification-information">Classification information</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/architecture/data.html#vendor-information">Vendor information</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/architecture/data.html#contract-information">Contract information</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/architecture/data.html#scheduling-updates-and-monitoring-progress">Scheduling updates and monitoring progress</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/architecture/data.html#a-look-at-how-discovery-data-fits-together">A look at how Discovery data fits together</a></li>
 </ul>
 </li>
-<li class="toctree-l1"><a class="reference internal" href="architecture/assets.html">Discovery static assets</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="architecture/assets.html#asset-types">Asset Types</a></li>
-<li class="toctree-l2"><a class="reference internal" href="architecture/assets.html#generating-static-assets">Generating static assets</a></li>
-<li class="toctree-l2"><a class="reference internal" href="architecture/assets.html#asset-generation-collection-triggers">Asset generation / collection triggers</a></li>
+<li class="toctree-l1"><a class="reference internal" href="docs/architecture/assets.html">Discovery static assets</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="docs/architecture/assets.html#asset-types">Asset Types</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/architecture/assets.html#generating-static-assets">Generating static assets</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/architecture/assets.html#asset-generation-collection-triggers">Asset generation / collection triggers</a></li>
 </ul>
 </li>
 </ul>
@@ -285,38 +285,38 @@
 <div class="toctree-wrapper compound">
 <p class="caption"><span class="caption-text">Processes</span></p>
 <ul>
-<li class="toctree-l1"><a class="reference internal" href="process/readme.html">Discovery processes</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="process/readme.html#overview">Overview</a></li>
-<li class="toctree-l2"><a class="reference internal" href="process/readme.html#topics">Topics</a></li>
+<li class="toctree-l1"><a class="reference internal" href="docs/process/readme.html">Discovery processes</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="docs/process/readme.html#overview">Overview</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/process/readme.html#topics">Topics</a></li>
 </ul>
 </li>
-<li class="toctree-l1"><a class="reference internal" href="process/development.html">Discovery development process</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="process/development.html#version-control-and-branching-strategy">Version control and branching strategy</a></li>
-<li class="toctree-l2"><a class="reference internal" href="process/development.html#issues-and-pull-requests">Issues and pull requests</a></li>
-<li class="toctree-l2"><a class="reference internal" href="process/development.html#merges-and-deployments">Merges and deployments</a></li>
-<li class="toctree-l2"><a class="reference internal" href="process/development.html#quality-assurance">Quality assurance</a></li>
+<li class="toctree-l1"><a class="reference internal" href="docs/process/development.html">Discovery development process</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="docs/process/development.html#version-control-and-branching-strategy">Version control and branching strategy</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/process/development.html#issues-and-pull-requests">Issues and pull requests</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/process/development.html#merges-and-deployments">Merges and deployments</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/process/development.html#quality-assurance">Quality assurance</a></li>
 </ul>
 </li>
-<li class="toctree-l1"><a class="reference internal" href="process/testing.html">Discovery testing process</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="process/testing.html#code-evaluation">Code evaluation</a></li>
-<li class="toctree-l2"><a class="reference internal" href="process/testing.html#unit-testing">Unit testing</a></li>
-<li class="toctree-l2"><a class="reference internal" href="process/testing.html#acceptance-testing">Acceptance testing</a></li>
-<li class="toctree-l2"><a class="reference internal" href="process/testing.html#testing-on-circleci">Testing on CircleCI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="docs/process/testing.html">Discovery testing process</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="docs/process/testing.html#code-evaluation">Code evaluation</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/process/testing.html#unit-testing">Unit testing</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/process/testing.html#acceptance-testing">Acceptance testing</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/process/testing.html#testing-on-circleci">Testing on CircleCI</a></li>
 </ul>
 </li>
-<li class="toctree-l1"><a class="reference internal" href="process/deployment.html">Discovery deployment process</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="process/deployment.html#deployment-locally">Deployment locally</a></li>
-<li class="toctree-l2"><a class="reference internal" href="process/deployment.html#deployment-on-circleci">Deployment on CircleCI</a></li>
+<li class="toctree-l1"><a class="reference internal" href="docs/process/deployment.html">Discovery deployment process</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="docs/process/deployment.html#deployment-locally">Deployment locally</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/process/deployment.html#deployment-on-circleci">Deployment on CircleCI</a></li>
 </ul>
 </li>
-<li class="toctree-l1"><a class="reference internal" href="process/management.html">Discovery management</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="process/management.html#logging">Logging</a></li>
-<li class="toctree-l2"><a class="reference internal" href="process/management.html#monitoring">Monitoring</a></li>
+<li class="toctree-l1"><a class="reference internal" href="docs/process/management.html">Discovery management</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="docs/process/management.html#logging">Logging</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/process/management.html#monitoring">Monitoring</a></li>
 </ul>
 </li>
-<li class="toctree-l1"><a class="reference internal" href="process/contributing.html">Contributing to Discovery</a><ul>
-<li class="toctree-l2"><a class="reference internal" href="process/contributing.html#public-domain">Public domain</a></li>
-<li class="toctree-l2"><a class="reference internal" href="process/contributing.html#ways-to-contribute">Ways to contribute</a></li>
+<li class="toctree-l1"><a class="reference internal" href="docs/process/contributing.html">Contributing to Discovery</a><ul>
+<li class="toctree-l2"><a class="reference internal" href="docs/process/contributing.html#public-domain">Public domain</a></li>
+<li class="toctree-l2"><a class="reference internal" href="docs/process/contributing.html#ways-to-contribute">Ways to contribute</a></li>
 </ul>
 </li>
 </ul>

--- a/scripts/deploy-docs.sh
+++ b/scripts/deploy-docs.sh
@@ -81,7 +81,7 @@ then
 
     # Fetch source repository
     git clone -b "$SOURCE_BRANCH" "$GH_PAGES_REMOTE" "$BUILD_DIR"
-    cd "$BUILD_DIR"
+    cd "$BUILD_DIR"/docs
     
     # Build and preserve documentation
     make html

--- a/scripts/deploy-docs.sh
+++ b/scripts/deploy-docs.sh
@@ -93,6 +93,9 @@ then
     git checkout "$GH_PAGES_BRANCH"
     rm -Rf *
     # Testing
+    # TODO: Need to copy index file into app/docs for django
+    # template. Might also have to manually change html for
+    # new links to open in new tabs.
     mkdir -p /app/app/static/docs2
     mv $SITE_TEMP_DIR/* /app/app/static/docs2
     cd /app/app/static/docs2


### PR DESCRIPTION
doc-index.html: Some of the links on the docs index page under the django template were missing the /docs/ subpath. Also, I some functionality to the html page that should open external links in new windows. 

deploy-docs.sh: when we added develop to the config.yml, the dep-docs job failed and spat out this:

Cloning into '/tmp/gh-pages'...
remote: Enumerating objects: 114, done.        
remote: Counting objects: 100% (114/114), done.        
remote: Compressing objects: 100% (83/83), done.        
remote: Total 55478 (delta 61), reused 63 (delta 28), pack-reused 55364        
Receiving objects: 100% (55478/55478), 200.06 MiB | 54.88 MiB/s, done.
Resolving deltas: 100% (25169/25169), done.
make: *** No rule to make target 'html'.  Stop.

Which seems like it wasn't in the proper directory to invoke the docs Makefile. I added a cd that should put it in the correct directory. 
