### PR TITLE
fixed ga create call to google analytics script

### DIFF
--- a/app/discovery/templates/index.html
+++ b/app/discovery/templates/index.html
@@ -25,7 +25,7 @@
     <script>
       window.ga=window.ga||function(){(ga.q=ga.q||[]).push(arguments)};ga.l=+new Date;
       pageUrl = window.location.href;
-      ga('create', "{{GA_TRACKING_ID}}", 'auto', {'cookieFlags': 'Secure; HttpOnly'});
+      ga('create', "{{GA_TRACKING_ID}}", {'cookieFlags': 'Secure; HttpOnly'});
 
       ga('require', 'urlChangeTracker', {
         fieldsObj: {


### PR DESCRIPTION
ga.create had too many arguments. cookies weren't being created. should be good now.