### PR TITLE
adjust disk quotas and memory limtis on a per application basis

### DIFF
--- a/cf/base-manifest.yml
+++ b/cf/base-manifest.yml
@@ -1,7 +1,6 @@
 ---
 path: ../
 buildpack: https://github.com/cloudfoundry/python-buildpack
-disk_quota: 5G
 timeout: 180
 stack: cflinuxfs3
 services:

--- a/cf/base-scheduler-manifest.yml
+++ b/cf/base-scheduler-manifest.yml
@@ -2,4 +2,5 @@
 inherit: base-worker-manifest.yml
 
 command: scripts/init-db.sh /dev/stderr && celery --workdir=app --app=discovery beat --loglevel=info
-memory: 500M
+memory: 250M
+disk_quota: 2G

--- a/cf/base-web-manifest.yml
+++ b/cf/base-web-manifest.yml
@@ -2,7 +2,8 @@
 inherit: base-manifest.yml
 
 command: scripts/init-webserver.sh /dev/stderr && cd app && waitress-serve --expose-tracebacks --url-scheme=https --port=$PORT discovery.wsgi:application
-memory: 1024M
+memory: 512M
+disk_quota: 2G
 services:
   - discovery-config
   - discovery-db

--- a/cf/base-worker-manifest.yml
+++ b/cf/base-worker-manifest.yml
@@ -4,4 +4,5 @@ inherit: base-manifest.yml
 command: celery --workdir=app --app=discovery worker --loglevel=error --concurrency=2
 no-route: true
 health-check-type: process
-memory: 500M
+memory: 1000M
+disk_quota: 10G


### PR DESCRIPTION
i am adjusting the manifests to give the worker a 10g of space and 1g of memory. if it fails after this, there's no possible way it can be a disk quota issua. 